### PR TITLE
Added average_init_density to Template ModelConfig

### DIFF
--- a/method_template/template_config.py
+++ b/method_template/template_config.py
@@ -38,6 +38,7 @@ method_template = MethodSpecification(
             ),
             model=TemplateModelConfig(
                 eval_num_rays_per_chunk=1 << 15,
+                average_init_density=0.01,
             ),
         ),
         optimizers={
@@ -47,7 +48,7 @@ method_template = MethodSpecification(
                 "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
             },
             "fields": {
-                "optimizer": RAdamOptimizerConfig(lr=1e-2, eps=1e-15),
+                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
                 "scheduler": ExponentialDecaySchedulerConfig(lr_final=1e-4, max_steps=50000),
             },
             "camera_opt": {


### PR DESCRIPTION
MR following up [this issue](https://github.com/nerfstudio-project/nerfstudio/issues/3238#issuecomment-2173986047)

When trying to create a new custom method base on this template, I faced some problems regarding the training results.
After investigation the issue I found out adding the ``average_init_density`` in the method model configurations and setting it to ``0.01`` (was ``1`` by default) and also changing ``RAAdamOptimizer`` to ``AdamOptimizer`` (Also like they do it in the nerfacto model) solved the problem and the model reached the same results than the nerfacto model it is inheriting from.

Results:

Before
<img width="300" src="https://github.com/nerfstudio-project/nerfstudio-method-template/assets/19672657/ce42e496-a70c-4f65-9695-f0f14dd6a2e8" />

With the new configuration:
<img width="300" src="https://github.com/nerfstudio-project/nerfstudio-method-template/assets/19672657/555e2e0a-1592-4adb-8b73-c8385b3fb8bb" />
